### PR TITLE
make it possible to serve with a prefixed URL

### DIFF
--- a/logbot.py
+++ b/logbot.py
@@ -73,7 +73,8 @@ app = Flask(__name__)
 app.config["TEMPLATES_AUTO_RELOAD"] = True
 
 # The URL prefix on the server
-app.config["APPLICATION_ROOT"] = "/irclogs"
+APPLICATION_ROOT = os.getenv("APPLICATION_ROOT", "/irclocs")
+app.config["APPLICATION_ROOT"] = APPLICATION_ROOT
 
 @app.template_filter('md5')
 def format_md5(value):

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,5 +2,5 @@
 <title>List of channels</title>
 
 {% for channel in channels %}
-    <li><a href="/channel/{{ channel.name|urlencode }}">{{ channel.name }}</a></li>
+    <li><a href="{{ url_prefix | urlencode }}/channel/{{ channel.name | urlencode }}">{{ channel.name }}</a></li>
 {% endfor %}

--- a/templates/channels.html
+++ b/templates/channels.html
@@ -9,12 +9,12 @@
     <a href="..">Back</a>
     {% endif %}
 
-    <form id="searchform" method="get" action="/search/">
+    <form id="searchform" method="get" action="{{ url_prefix | urlencode }}/search/">
         <input type="text" name="query"/>
         <input type="submit" value="Search"/>
     </form>
 </div>
 
 {% for channel in channels %}
-    <li><a href="/channels/{{ channel.name|urlencode }}">{{ channel.name }}</a></li>
+    <li><a href="{{ url_prefix | urlencode }}/channels/{{ channel.name|urlencode }}">{{ channel.name }}</a></li>
 {% endfor %}

--- a/templates/days.html
+++ b/templates/days.html
@@ -9,7 +9,7 @@
     <a href="..">Back</a>
     {% endif %}
 
-    <form id="searchform" method="get" action="/search/channel/{{channel.name|urlencode}}/">
+    <form id="searchform" method="get" action="{{ url_prefix | urlencode }}/search/channel/{{ channel.name | urlencode }}/">
         <input type="text" name="query"/>
         <input type="submit" value="Search"/>
     </form>
@@ -17,7 +17,7 @@
 
 {% for day in days %}
 <li>
-    <a href="/channels/{{ channel.name|urlencode }}/{{ day.date }}">
+    <a href="{{ url_prefix | urlencode }}/channels/{{ channel.name|urlencode }}/{{ day.date }}">
         {{ day.date }}
     </a>
 </li>

--- a/templates/messages.html
+++ b/templates/messages.html
@@ -26,7 +26,7 @@
     <a href="..">Back</a>
     {% endif %}
 
-    <form id="searchform" method="get" action="/search/channel/{{channel.name|urlencode}}/">
+    <form id="searchform" method="get" action="{{ url_prefix | urlencode }}/search/channel/{{ channel.name | urlencode }}/">
         <input type="text" name="query"/>
         <input type="submit" value="Search"/>
     </form>


### PR DESCRIPTION
In case one doesn't want to run under localhost:5000/ but instead
something like localhost:5000/irclogs/, this will help, and it will
actually default to "/irclogs" as prefix.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>